### PR TITLE
don't format the address when revoking permissions 

### DIFF
--- a/client/precompile/permission/permission_service.py
+++ b/client/precompile/permission/permission_service.py
@@ -50,9 +50,9 @@ class PermissionService:
         related api:
         function remove(string table_name, string addr) public returns(int256);
         """
-        fmt_accout_address = common.check_and_format_address(account_address)
+        common.check_and_format_address(account_address)
         fn_name = "remove"
-        fn_args = [table_name, fmt_accout_address]
+        fn_args = [table_name, account_address]
         return self.client.send_transaction_getReceipt(fn_name, fn_args, self.gasPrice)
 
     @staticmethod

--- a/console_utils/precompile.py
+++ b/console_utils/precompile.py
@@ -214,7 +214,7 @@ class Precompile:
         """
         print cns information
         """
-        common.print_result(cns_info)
+        # common.print_result(cns_info)
         for cns_item in cns_info:
             cns_obj = json.loads(cns_item)
             i = 0


### PR DESCRIPTION
1. remove the display of detailed cns info
2.don't format the address when revoking permissions from the given user account