### PR TITLE
modify to make console output more friendly

### DIFF
--- a/client/bcosclient.py
+++ b/client/bcosclient.py
@@ -175,7 +175,7 @@ class BcosClient:
             else:
                 raise BcosError(-1, None, ("{} failed,"
                                            " params: {}, response: {}, error information: {}").
-                                format(cmd, params, response, e))
+                                format(cmd, params, json.dumps(response), e))
 
     def getNodeVersion(self):
         """

--- a/console_utils/rpc_console.py
+++ b/console_utils/rpc_console.py
@@ -218,7 +218,7 @@ class RPCConsole:
             return
         self.parse_output(cmd, params[2], result)
 
-    def convertHexToOct(self, cmd, json_str):
+    def convertHexToDec(self, cmd, json_str):
         if cmd == "getTotalTransactionCount":
             json_str["blockNumber"] = int(json_str["blockNumber"], 16)
             json_str["failedTxSum"] = int(json_str["failedTxSum"], 16)
@@ -239,7 +239,7 @@ class RPCConsole:
         ret_json = eval(function_name)(*params)
         common.print_info("INFO", self.cmd)
         if cmd in RPCConsole.functions["human_friendly_output"]:
-            ret_json = self.convertHexToOct(cmd, ret_json)
+            ret_json = self.convertHexToDec(cmd, ret_json)
         common.print_result(ret_json)
         return ret_json
 


### PR DESCRIPTION
https://github.com/FISCO-BCOS/python-sdk/issues/74

```bash
INFO >> user input : ['getSealerList']

ERROR >> execute getSealerList failed
ERROR >> error information: init bcosclient failed, reason: (-1, None, 'getBlockNumber failed, params: [1], response: {"result": {"error": {"code": -40009, "data": null, "message": "Don\'t send request to this node who doesn\'t belong to the group"}, "id": 0, "jsonrpc": "2.0"}}, error information: (-40009, None, "Don\'t send 
request to this node who doesn\'t belong to the group")')
```