### PR TITLE
result optimization

### DIFF
--- a/client/common/common.py
+++ b/client/common/common.py
@@ -283,9 +283,9 @@ def print_tx_result(outputresults):
     """
     for result in outputresults:
         if type(result) is bytes:
-            print("{}".format(bytesToHex(result)),end='\n')
+            print("{}".format(bytesToHex(result)), end='\n')
             continue
-        print("{}".format(result),end='\n')
+        print("{}".format(result), end='\n')
 
 
 def check_result(result):

--- a/client/common/common.py
+++ b/client/common/common.py
@@ -283,9 +283,9 @@ def print_tx_result(outputresults):
     """
     for result in outputresults:
         if type(result) is bytes:
-            print("{}, ".format(bytesToHex(result)))
+            print("{}".format(bytesToHex(result)),end='\n')
             continue
-        print("{}, ".format(result))
+        print("{}".format(result),end='\n')
 
 
 def check_result(result):


### PR DESCRIPTION
Issues75 has been completed, but the separator of the returned result is `,`. when only `helloword` is saved, the output is `helloword 
 ,`. It's very inhumane.