### PR TITLE
channel协议模式，交易防重机制下，无判断方式

### DIFF
--- a/client/bcosclient.py
+++ b/client/bcosclient.py
@@ -396,6 +396,13 @@ class BcosClient:
         """
         get blockNumber from _block_notify directly when use channelHandler
         """
+        tick = time.time()
+        tickstamp = tick - self.lastblocklimittime
+        if tickstamp > 100:  # get blocklimit every 100sec
+            blockNumber = self.getBlockNumber()
+            self.channel_handler.blockNumber=blockNumber
+            self.channel_handler.setBlockNumber(blockNumber)
+            self.lastblocklimittime=tick
         return self.channel_handler.blockNumber + self.blockLimit
 
     def RPC_getBlocklimit(self):

--- a/client/bcosclient.py
+++ b/client/bcosclient.py
@@ -401,9 +401,9 @@ class BcosClient:
         # get blocklimit every 100sec
         if tickstamp > 100:
             blockNumber = self.getBlockNumber()
-            self.channel_handler.blockNumber=blockNumber
+            self.channel_handler.blockNumber = blockNumber
             self.channel_handler.setBlockNumber(blockNumber)
-            self.lastblocklimittime=tick
+            self.lastblocklimittime = tick
         return self.channel_handler.blockNumber + self.blockLimit
 
     def RPC_getBlocklimit(self):

--- a/client/bcosclient.py
+++ b/client/bcosclient.py
@@ -398,7 +398,8 @@ class BcosClient:
         """
         tick = time.time()
         tickstamp = tick - self.lastblocklimittime
-        if tickstamp > 100:  # get blocklimit every 100sec
+        # get blocklimit every 100sec
+        if tickstamp > 100:
             blockNumber = self.getBlockNumber()
             self.channel_handler.blockNumber=blockNumber
             self.channel_handler.setBlockNumber(blockNumber)


### PR DESCRIPTION
增加了按100秒查询一次链上区块高度，避免每条交易都查，减少SDK与节点的交互频率，提高效率