### PR TITLE
Bug fixed in datatype_parser get_function_output_abi

### DIFF
--- a/client/datatype_parser.py
+++ b/client/datatype_parser.py
@@ -184,7 +184,7 @@ class DatatypeParser:
     def get_function_outputs_abi(self, fn_name):
         fn_abi = self.get_function_abi(fn_name)
         if fn_abi is not None:
-            return fn_name["outputs"]
+            return fn_abi["outputs"]
         return None
 
     def get_func_signature(self, name):


### PR DESCRIPTION
`get_function_output_abi` should returns `fn_abi["output"]`