### PR TITLE
Update bcos3client.py

### DIFF
--- a/bcos3sdk/bcos3client.py
+++ b/bcos3sdk/bcos3client.py
@@ -49,7 +49,7 @@ class Bcos3Client:
     group = ""
     node = None
     keypair = None
-    bcos3sdk = None
+    bcossdk = None
     logger = clientlogger.logger  # logging.getLogger("BcosClient")
     config = None
     sdk_version = None


### PR DESCRIPTION
The variable "bcos3sdk" in the class "Bcos3Client" should be renamed as "bcossdk". Otherwise, there will be the error:  "AttributeError: 'Bcos3Client' object has no attribute 'bcossdk'".